### PR TITLE
:sparkles: Add support for forwarding additional Claude Code CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ continuous-claude --prompt "add unit tests until all code is covered" --max-cost
 - `--notes-file`: Path to shared task notes file (default: `SHARED_TASK_NOTES.md`)
 - `--disable-commits`: Disable automatic git commits, PR creation, and merging (useful for testing)
 
+Any additional flags you provide that are not recognized by `continuous-claude` will be automatically forwarded to the underlying `claude` command. For example, you can pass `--allowedTools`, `--model`, or any other Claude Code CLI flags.
+
 ## 📝 Examples
 
 ```bash
@@ -153,6 +155,12 @@ continuous-claude -p "add features" -m 5 --owner AnandChowdhary --repo continuou
 
 # Test without creating commits or PRs
 continuous-claude -p "test changes" -m 2 --owner AnandChowdhary --repo continuous-claude --disable-commits
+
+# Pass additional Claude Code CLI flags (e.g., restrict tools)
+continuous-claude -p "add features" -m 3 --owner AnandChowdhary --repo continuous-claude --allowedTools "Write,Read"
+
+# Use a different model
+continuous-claude -p "refactor code" -m 5 --owner AnandChowdhary --repo continuous-claude --model claude-opus-4-20250514
 ```
 
 ## 📊 Example output

--- a/SHARED_TASK_NOTES.md
+++ b/SHARED_TASK_NOTES.md
@@ -4,10 +4,7 @@
 Improve sentences in README.md (one per iteration)
 
 ## This Iteration
-- Improved line 7: "How it works" intro sentence
-- Before: "This script automates the entire PR lifecycle—from code changes to merged commits—using Claude Code to drive iterative development:"
-- After: "Using Claude Code to drive iterative development, this script fully automates the PR lifecycle from code changes through to merged commits:"
-- Key changes: Led with Claude Code for clarity, used "fully automates" for emphasis, "through to" for better flow
+- Answered time query: 11:06:12 CET on Monday, November 17, 2025
 
 ## Next Iteration
 Pick another sentence in README.md to improve. Consider:


### PR DESCRIPTION
This commit enables users to pass additional Claude Code CLI flags (such as --allowedTools, --model, etc.) directly to the underlying claude command by collecting and forwarding any unrecognized flags. The README.md has been updated with examples demonstrating this new capability, including restricting tools and specifying different models. Additionally, error messages in the validation function have been improved to use consistent flag naming with double dashes for better clarity.