### PR TITLE
Add default reviewer prompt for empty review flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ continuous-claude --prompt "add unit tests until all code is covered" --max-dura
 - `--dry-run`: Simulate execution without making changes
 - `--completion-signal <phrase>`: Phrase that agents output when entire project is complete (default: `CONTINUOUS_CLAUDE_PROJECT_COMPLETE`)
 - `--completion-threshold <num>`: Number of consecutive completion signals required to stop early (default: `3`)
-- `-r, --review-prompt`: Run a reviewer pass after each iteration to validate changes (e.g., run build/lint/tests and fix any issues)
+- `-r, --review-prompt [text]`: Run a reviewer pass after each iteration to validate changes. If you omit the text, Continuous Claude uses a comprehensive default review prompt that reviews the diff, runs available checks, simplifies changed code, and verifies the app where relevant.
 
 Any additional flags you provide that are not recognized by `continuous-claude` will be automatically forwarded to the selected provider command. You can also use `--` to explicitly stop parsing `continuous-claude` options and forward the rest to the provider CLI.
 
@@ -238,6 +238,9 @@ continuous-claude -p "fix all bugs" -m 20 --completion-signal "ALL_BUGS_FIXED" -
 
 # Use a reviewer to validate and fix changes after each iteration
 continuous-claude -p "add new feature" -m 5 -r "Run npm test and npm run lint, fix any failures"
+
+# Use the default reviewer prompt
+continuous-claude -p "add new feature" -m 5 -r
 
 # Explicitly specify owner and repo (useful if git remote is not set up or not a GitHub repo)
 continuous-claude -p "add features" -m 5 --owner myuser --repo myproject

--- a/continuous_claude.sh
+++ b/continuous_claude.sh
@@ -55,6 +55,8 @@ You are performing a review pass on changes just made by another developer. This
 
 **Do NOT commit or push changes** - The automation will handle committing and pushing your changes after you finish. Just focus on validating and fixing any issues."
 
+PROMPT_DEFAULT_REVIEWER="Review the currently changed files on this branch before I ship. Look at the diff and read everything that changed. Run the test suite, typecheck, lint, formatter, etc., whatever is available, and fix anything that fails. Invoke the /simplify skill on the changed files to dedupe, extract clean abstractions where patterns repeat, and tighten naming, but don't over-abstract. Then start the dev server if any, and drive the app with real tooling, like a browser test similar to the agent-browser CLI or whatever else is relevant to this project. Screenshot surfaces you touched, click through the golden path and edge cases, and watch the dev server logs and browser console for warnings or errors where relevant. Report back with what changed, what you simplified, test results, and a screenshot-backed walkthrough, and flag anything you couldn't verify. No need to commit or push."
+
 PROMPT_CI_FIX_CONTEXT="## CI FAILURE FIX CONTEXT
 
 You are analyzing and fixing a CI/CD failure for a pull request.
@@ -236,7 +238,8 @@ OPTIONAL FLAGS:
     --dry-run                     Simulate execution without making changes
     --completion-signal <phrase>  Phrase that agents output when project is complete (default: "CONTINUOUS_CLAUDE_PROJECT_COMPLETE")
     --completion-threshold <num>  Number of consecutive signals to stop early (default: 3)
-    -r, --review-prompt <text>    Run a reviewer pass after each iteration to validate changes
+    -r, --review-prompt [text]    Run a reviewer pass after each iteration to validate changes
+                                  Uses a comprehensive default review prompt when text is omitted
                                   (e.g., run build/lint/tests and fix any issues)
     --disable-ci-retry            Disable automatic CI failure retry (enabled by default)
     --ci-retry-max <number>       Maximum CI fix attempts per PR (default: 1)
@@ -933,9 +936,24 @@ parse_arguments() {
                 COMPLETION_THRESHOLD="$2"
                 shift 2
                 ;;
+            --review-prompt=*)
+                REVIEW_PROMPT="${1#*=}"
+                if [ -z "$REVIEW_PROMPT" ]; then
+                    REVIEW_PROMPT="$PROMPT_DEFAULT_REVIEWER"
+                fi
+                shift
+                ;;
             -r|--review-prompt)
-                REVIEW_PROMPT="$2"
-                shift 2
+                if [ $# -gt 1 ] && [ -z "$2" ]; then
+                    REVIEW_PROMPT="$PROMPT_DEFAULT_REVIEWER"
+                    shift 2
+                elif [ $# -gt 1 ] && [[ "$2" != -* ]]; then
+                    REVIEW_PROMPT="$2"
+                    shift 2
+                else
+                    REVIEW_PROMPT="$PROMPT_DEFAULT_REVIEWER"
+                    shift
+                fi
                 ;;
             --disable-ci-retry)
                 CI_RETRY_ENABLED=false

--- a/continuous_claude.sh.sha256
+++ b/continuous_claude.sh.sha256
@@ -1,1 +1,1 @@
-5ba29075f2ca1978237e4c35a8b0c7cda06273fdd17b371aa5da3754539c23d6  continuous_claude.sh
+04819bff757c573405a6d8d79cde7cdf76e787eb241d34246391da75fe68cefd  continuous_claude.sh

--- a/tests/test_continuous_claude.bats
+++ b/tests/test_continuous_claude.bats
@@ -67,6 +67,29 @@ setup() {
     assert_equal "${EXTRA_CLAUDE_FLAGS[0]}" "--model"
 }
 
+@test "parse_arguments handles review prompt value" {
+    source "$SCRIPT_PATH"
+    parse_arguments -r "Run tests and lint"
+
+    assert_equal "$REVIEW_PROMPT" "Run tests and lint"
+}
+
+@test "parse_arguments uses default review prompt when -r has no value" {
+    source "$SCRIPT_PATH"
+    parse_arguments -p "test" -r -m 1
+
+    assert_equal "$PROMPT" "test"
+    assert_equal "$MAX_RUNS" "1"
+    assert_equal "$REVIEW_PROMPT" "$PROMPT_DEFAULT_REVIEWER"
+}
+
+@test "parse_arguments uses default review prompt for empty equals value" {
+    source "$SCRIPT_PATH"
+    parse_arguments --review-prompt=
+
+    assert_equal "$REVIEW_PROMPT" "$PROMPT_DEFAULT_REVIEWER"
+}
+
 @test "parse_arguments handles auto-update flag" {
     source "$SCRIPT_PATH"
     AUTO_UPDATE="false"
@@ -2586,6 +2609,8 @@ setup() {
     run show_help
     assert_output --partial "--disable-comment-review"
     assert_output --partial "--comment-review-max"
+    assert_output --partial "--review-prompt [text]"
+    assert_output --partial "Uses a comprehensive default review prompt"
 }
 
 @test "relpath function handles path outside PWD" {


### PR DESCRIPTION
## Summary
- add a built-in default reviewer prompt used when `-r`/`--review-prompt` is provided without text
- keep explicit custom reviewer prompts working, including `--review-prompt=...`
- document the optional reviewer prompt argument and add parser/help coverage

Closes #54.

## Tests
- `bash -n continuous_claude.sh install.sh`
- `shellcheck continuous_claude.sh install.sh`
- `git diff --check`
- `tests/libs/bats/bin/bats tests/test_continuous_claude.bats --filter "review prompt|show_help includes comment review"`
- `tests/libs/bats/bin/bats tests/test_continuous_claude.bats`
- `./continuous_claude.sh -p "empty reviewer prompt smoke" -r -m 1 --disable-commits --disable-updates --dry-run`