### PR TITLE
Surface PR merge errors accurately

### DIFF
--- a/continuous_claude.sh
+++ b/continuous_claude.sh
@@ -1457,8 +1457,12 @@ merge_pr_and_cleanup() {
     esac
 
     echo "🔀 $iteration_display Merging PR #$pr_number with strategy: $MERGE_STRATEGY..." >&2
-    if ! gh pr merge "$pr_number" --repo "$owner/$repo" $merge_flag >/dev/null 2>&1; then
-        echo "⚠️  $iteration_display Failed to merge PR (may have conflicts or be blocked)" >&2
+    local merge_output
+    if ! merge_output=$(gh pr merge "$pr_number" --repo "$owner/$repo" $merge_flag 2>&1); then
+        echo "⚠️  $iteration_display Failed to merge PR: $merge_output" >&2
+        if echo "$merge_output" | grep -qi "upgrade to github pro\\|make this repository public\\|http 403\\|status code 403\\|resource not accessible"; then
+            echo "   GitHub reported an API or plan restriction. This is not a merge queue failure; check repository visibility, branch protection/ruleset availability, and your GitHub plan." >&2
+        fi
         return 1
     fi
 
@@ -2724,7 +2728,7 @@ handle_iteration_success() {
             if ! continuous_claude_commit "$iteration_display" "$branch_name" "$main_branch"; then
                 error_count=$((error_count + 1))
                 extra_iterations=$((extra_iterations + 1))
-                echo "❌ $iteration_display PR merge queue failed ($error_count consecutive errors)" >&2
+                echo "❌ $iteration_display PR workflow failed ($error_count consecutive errors)" >&2
                 if [ "$error_count" -ge 3 ]; then
                     echo "❌ Fatal: 3 consecutive errors occurred. Exiting." >&2
                     exit 1

--- a/continuous_claude.sh.sha256
+++ b/continuous_claude.sh.sha256
@@ -1,1 +1,1 @@
-672933f567592a78c62361ea9ebe25e60aba1cbfe96b55ecccae3ec8a01d63fd  continuous_claude.sh
+753420e22ddc55de2cc50e3562e64d86a4a8f9bc6dc9e7161c3dda27eb7ca83a  continuous_claude.sh

--- a/tests/test_continuous_claude.bats
+++ b/tests/test_continuous_claude.bats
@@ -1870,6 +1870,51 @@ require_pwsh() {
     refute_output --partial "claude should not be called"
 }
 
+@test "merge_pr_and_cleanup surfaces GitHub plan restriction errors" {
+    source "$SCRIPT_PATH"
+
+    MERGE_STRATEGY="squash"
+
+    function gh() {
+        if [ "$1" = "pr" ] && [ "$2" = "update-branch" ]; then
+            echo "already up-to-date"
+            return 1
+        fi
+        if [ "$1" = "pr" ] && [ "$2" = "merge" ]; then
+            echo "HTTP 403: Upgrade to GitHub Pro or make this repository public to enable this feature." >&2
+            return 1
+        fi
+        return 1
+    }
+    export -f gh
+
+    run merge_pr_and_cleanup "123" "owner" "repo" "test-branch" "(1/1)" "main"
+
+    assert_failure
+    assert_output --partial "Failed to merge PR: HTTP 403: Upgrade to GitHub Pro"
+    assert_output --partial "not a merge queue failure"
+}
+
+@test "handle_iteration_success reports PR workflow failure instead of merge queue failure" {
+    source "$SCRIPT_PATH"
+
+    ENABLE_COMMITS="true"
+    DISABLE_BRANCHES="false"
+    error_count=0
+    extra_iterations=0
+
+    function continuous_claude_commit() {
+        return 1
+    }
+    export -f continuous_claude_commit
+
+    run handle_iteration_success "(1/1)" '{"result":"ok","total_cost_usd":0}' "test-branch" "main"
+
+    assert_failure
+    assert_output --partial "PR workflow failed"
+    refute_output --partial "PR merge queue failed"
+}
+
 @test "wait_for_pr_checks prints initial waiting message once" {
     source "$SCRIPT_PATH"
     


### PR DESCRIPTION
## Summary
- preserve and print `gh pr merge` stderr instead of hiding the real GitHub error
- detect GitHub plan/API restriction messages and explain that they are not merge queue failures
- rename the outer full-PR failure message from "PR merge queue failed" to "PR workflow failed"
- add regression coverage for private-repo plan restriction output and the generic PR workflow failure message

Closes #48.

## Tests
- `bash -n continuous_claude.sh install.sh`
- `shellcheck continuous_claude.sh install.sh`
- `git diff --check`
- `sha256sum -c continuous_claude.sh.sha256`
- `tests/libs/bats/bin/bats tests/test_continuous_claude.bats --filter "merge_pr_and_cleanup|PR workflow failure"`
- `tests/libs/bats/bin/bats tests/test_continuous_claude.bats`