### PR TITLE
Retry transient commit and PR commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ continuous-claude --prompt "add unit tests until all code is covered" --max-dura
 - `--completion-signal <phrase>`: Phrase that agents output when entire project is complete (default: `CONTINUOUS_CLAUDE_PROJECT_COMPLETE`)
 - `--completion-threshold <num>`: Number of consecutive completion signals required to stop early (default: `3`)
 - `-r, --review-prompt [text]`: Run a reviewer pass after each iteration to validate changes. If you omit the text, Continuous Claude uses a comprehensive default review prompt that reviews the diff, runs available checks, simplifies changed code, and verifies the app where relevant.
+- `--command-retry-max <number>`: Maximum attempts for transient commit/push/PR-create commands before starting a new iteration (default: `3`)
+- `--command-retry-base-delay <seconds>`: Initial retry delay in seconds for transient commands, doubled after each failed attempt (default: `5`)
 
 Any additional flags you provide that are not recognized by `continuous-claude` will be automatically forwarded to the selected provider command. You can also use `--` to explicitly stop parsing `continuous-claude` options and forward the rest to the provider CLI.
 
@@ -269,6 +271,9 @@ continuous-claude -p "add new feature" -m 5 -r "Run npm test and npm run lint, f
 
 # Use the default reviewer prompt
 continuous-claude -p "add new feature" -m 5 -r
+
+# Retry transient commit/push/PR-create failures before abandoning the iteration
+continuous-claude -p "add new feature" -m 5 --command-retry-max 4 --command-retry-base-delay 10
 
 # Explicitly specify owner and repo (useful if git remote is not set up or not a GitHub repo)
 continuous-claude -p "add features" -m 5 --owner myuser --repo myproject

--- a/continuous_claude.sh
+++ b/continuous_claude.sh
@@ -125,6 +125,8 @@ CI_RETRY_ENABLED=true
 CI_RETRY_MAX_ATTEMPTS=1
 COMMENT_REVIEW_ENABLED=true
 COMMENT_REVIEW_MAX_ATTEMPTS=1
+COMMAND_RETRY_MAX_ATTEMPTS=3
+COMMAND_RETRY_BASE_DELAY=5
 
 parse_duration() {
     # Parse a duration string like "2h", "30m", "1h30m", "90s" to seconds
@@ -245,6 +247,9 @@ OPTIONAL FLAGS:
     --ci-retry-max <number>       Maximum CI fix attempts per PR (default: 1)
     --disable-comment-review      Disable automatic PR comment review (enabled by default)
     --comment-review-max <number> Maximum comment review attempts per PR (default: 1)
+    --command-retry-max <number>  Maximum attempts for transient commit/push/PR-create commands (default: 3)
+    --command-retry-base-delay <seconds>
+                                  Initial retry delay for transient commands (default: 5)
     --codex-input-cost-per-million <dollars>
                                   Input token rate for Codex --max-cost estimates
     --codex-output-cost-per-million <dollars>
@@ -971,6 +976,14 @@ parse_arguments() {
                 COMMENT_REVIEW_MAX_ATTEMPTS="$2"
                 shift 2
                 ;;
+            --command-retry-max)
+                COMMAND_RETRY_MAX_ATTEMPTS="$2"
+                shift 2
+                ;;
+            --command-retry-base-delay)
+                COMMAND_RETRY_BASE_DELAY="$2"
+                shift 2
+                ;;
             *)
                 # Collect unknown flags to forward to the selected provider CLI.
                 add_extra_agent_flag "$1"
@@ -1091,6 +1104,20 @@ validate_arguments() {
     if [ -n "$COMMENT_REVIEW_MAX_ATTEMPTS" ]; then
         if ! [[ "$COMMENT_REVIEW_MAX_ATTEMPTS" =~ ^[0-9]+$ ]] || [ "$COMMENT_REVIEW_MAX_ATTEMPTS" -lt 1 ]; then
             echo "❌ Error: --comment-review-max must be a positive integer" >&2
+            exit 1
+        fi
+    fi
+
+    if [ -n "$COMMAND_RETRY_MAX_ATTEMPTS" ]; then
+        if ! [[ "$COMMAND_RETRY_MAX_ATTEMPTS" =~ ^[0-9]+$ ]] || [ "$COMMAND_RETRY_MAX_ATTEMPTS" -lt 1 ]; then
+            echo "❌ Error: --command-retry-max must be a positive integer" >&2
+            exit 1
+        fi
+    fi
+
+    if [ -n "$COMMAND_RETRY_BASE_DELAY" ]; then
+        if ! [[ "$COMMAND_RETRY_BASE_DELAY" =~ ^[0-9]+$ ]]; then
+            echo "❌ Error: --command-retry-base-delay must be a non-negative integer" >&2
             exit 1
         fi
     fi
@@ -1584,7 +1611,7 @@ continuous_claude_commit() {
     if [ "$has_uncommitted_changes" = "true" ]; then
         echo "💬 $iteration_display Committing changes..." >&2
         
-        if ! run_agent_prompt_quiet "$PROMPT_COMMIT_MESSAGE"; then
+        if ! run_with_command_retry "$iteration_display commit command" run_agent_prompt_quiet "$PROMPT_COMMIT_MESSAGE"; then
             echo "⚠️  $iteration_display Failed to commit changes" >&2
             git checkout "$main_branch" >/dev/null 2>&1
             return 1
@@ -1608,15 +1635,16 @@ continuous_claude_commit() {
     local commit_body=$(echo "$commit_message" | tail -n +4)
 
     echo "📤 $iteration_display Pushing branch..." >&2
-    if ! git push -u origin "$branch_name" >/dev/null 2>&1; then
-        echo "⚠️  $iteration_display Failed to push branch" >&2
+    local push_output
+    if ! push_output=$(run_with_command_retry "$iteration_display push branch" git push -u origin "$branch_name"); then
+        echo "⚠️  $iteration_display Failed to push branch: $push_output" >&2
         git checkout "$main_branch" >/dev/null 2>&1
         return 1
     fi
 
     echo "🔨 $iteration_display Creating pull request..." >&2
     local pr_output
-    if ! pr_output=$(gh pr create --repo "$GITHUB_OWNER/$GITHUB_REPO" --title "$commit_title" --body "$commit_body" --base "$main_branch" 2>&1); then
+    if ! pr_output=$(run_with_command_retry "$iteration_display create PR" gh pr create --repo "$GITHUB_OWNER/$GITHUB_REPO" --title "$commit_title" --body "$commit_body" --base "$main_branch"); then
         echo "⚠️  $iteration_display Failed to create PR: $pr_output" >&2
         git checkout "$main_branch" >/dev/null 2>&1
         return 1
@@ -1730,7 +1758,7 @@ commit_on_current_branch() {
 
     echo "💬 $iteration_display Committing changes on current branch..." >&2
 
-    if ! run_agent_prompt_quiet "$PROMPT_COMMIT_MESSAGE"; then
+    if ! run_with_command_retry "$iteration_display commit command" run_agent_prompt_quiet "$PROMPT_COMMIT_MESSAGE"; then
         echo "⚠️  $iteration_display Failed to commit changes" >&2
         return 1
     fi
@@ -1904,6 +1932,38 @@ run_agent_prompt_quiet() {
             return 1
             ;;
     esac
+}
+
+run_with_command_retry() {
+    local label="$1"
+    shift
+
+    local attempt=1
+    local delay="${COMMAND_RETRY_BASE_DELAY:-5}"
+    local output=""
+    local exit_code=0
+
+    while [ "$attempt" -le "$COMMAND_RETRY_MAX_ATTEMPTS" ]; do
+        if output=$("$@" 2>&1); then
+            printf "%s" "$output"
+            return 0
+        fi
+
+        exit_code=$?
+        if [ "$attempt" -ge "$COMMAND_RETRY_MAX_ATTEMPTS" ]; then
+            printf "%s" "$output"
+            return "$exit_code"
+        fi
+
+        echo "⚠️  $label failed (attempt $attempt/$COMMAND_RETRY_MAX_ATTEMPTS): $output" >&2
+        echo "⏳ Retrying $label in ${delay}s..." >&2
+        sleep "$delay"
+        attempt=$((attempt + 1))
+        delay=$((delay * 2))
+    done
+
+    printf "%s" "$output"
+    return "$exit_code"
 }
 
 run_claude_provider_iteration() {

--- a/continuous_claude.sh.sha256
+++ b/continuous_claude.sh.sha256
@@ -1,1 +1,1 @@
-6dfdc2d0368b4e58dbd30f849a67f477d64460bc14f39f03dbd68b9e1f521ee4  continuous_claude.sh
+346a3fcbf07f3b2d51e652a6d29cd91b957c08e0d2f650b5ba636df51a8ee4a9  continuous_claude.sh

--- a/tests/test_continuous_claude.bats
+++ b/tests/test_continuous_claude.bats
@@ -186,6 +186,40 @@ require_pwsh() {
     assert_equal "$DISABLE_UPDATES" "true"
 }
 
+@test "parse_arguments handles command retry flags" {
+    source "$SCRIPT_PATH"
+    parse_arguments --command-retry-max 4 --command-retry-base-delay 2
+
+    assert_equal "$COMMAND_RETRY_MAX_ATTEMPTS" "4"
+    assert_equal "$COMMAND_RETRY_BASE_DELAY" "2"
+}
+
+@test "validate_arguments fails with invalid command-retry-max" {
+    source "$SCRIPT_PATH"
+    PROMPT="test"
+    MAX_RUNS="5"
+    GITHUB_OWNER="user"
+    GITHUB_REPO="repo"
+    COMMAND_RETRY_MAX_ATTEMPTS="invalid"
+
+    run validate_arguments
+    assert_failure
+    assert_output --partial "Error: --command-retry-max must be a positive integer"
+}
+
+@test "validate_arguments fails with invalid command-retry-base-delay" {
+    source "$SCRIPT_PATH"
+    PROMPT="test"
+    MAX_RUNS="5"
+    GITHUB_OWNER="user"
+    GITHUB_REPO="repo"
+    COMMAND_RETRY_BASE_DELAY="invalid"
+
+    run validate_arguments
+    assert_failure
+    assert_output --partial "Error: --command-retry-base-delay must be a non-negative integer"
+}
+
 @test "render_notes_prompt uses current notes-file value" {
     source "$SCRIPT_PATH"
     NOTES_FILE="CUSTOM_NOTES.md"
@@ -958,6 +992,41 @@ require_pwsh() {
     assert_success
     run grep -q "commit please" "$args_file"
     assert_success
+}
+
+@test "run_with_command_retry retries with exponential backoff" {
+    source "$SCRIPT_PATH"
+    COMMAND_RETRY_MAX_ATTEMPTS=3
+    COMMAND_RETRY_BASE_DELAY=2
+
+    echo "0" > "$BATS_TEST_TMPDIR/retry_count"
+    : > "$BATS_TEST_TMPDIR/sleeps"
+
+    function flaky_command() {
+        local count
+        count=$(cat "$BATS_TEST_TMPDIR/retry_count")
+        count=$((count + 1))
+        echo "$count" > "$BATS_TEST_TMPDIR/retry_count"
+        if [ "$count" -lt 3 ]; then
+            echo "rate limited"
+            return 1
+        fi
+        echo "ok"
+        return 0
+    }
+
+    function sleep() {
+        echo "$1" >> "$BATS_TEST_TMPDIR/sleeps"
+        return 0
+    }
+    export -f flaky_command sleep
+
+    run run_with_command_retry "test command" flaky_command
+
+    assert_success
+    assert_output --partial "ok"
+    assert_equal "$(cat "$BATS_TEST_TMPDIR/retry_count")" "3"
+    assert_equal "$(tr '\n' ',' < "$BATS_TEST_TMPDIR/sleeps")" "2,4,"
 }
 
 @test "get_latest_version returns version when gh is available" {
@@ -1870,6 +1939,77 @@ require_pwsh() {
     refute_output --partial "claude should not be called"
 }
 
+@test "continuous_claude_commit retries transient PR creation failures" {
+    source "$SCRIPT_PATH"
+
+    ENABLE_COMMITS="true"
+    DRY_RUN="false"
+    GITHUB_OWNER="user"
+    GITHUB_REPO="repo"
+    COMMAND_RETRY_MAX_ATTEMPTS=2
+    COMMAND_RETRY_BASE_DELAY=1
+
+    function git() {
+        case "$1 $2 $3 $4" in
+            "rev-parse --git-dir"*)
+                return 0
+                ;;
+            "diff --quiet --ignore-submodules=dirty"*)
+                return 0
+                ;;
+            "diff --cached --quiet --ignore-submodules=dirty"*)
+                return 0
+                ;;
+            "ls-files --others --exclude-standard"*)
+                echo ""
+                ;;
+            "rev-list --count main..test-branch"*)
+                echo "1"
+                ;;
+            "log -1 --format=%B"*)
+                echo "Test commit message"
+                ;;
+            "push -u origin test-branch"*)
+                return 0
+                ;;
+            checkout*|branch*)
+                return 0
+                ;;
+        esac
+        return 0
+    }
+    export -f git
+
+    echo "0" > "$BATS_TEST_TMPDIR/pr_create_count"
+    function gh() {
+        if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+            local count
+            count=$(cat "$BATS_TEST_TMPDIR/pr_create_count")
+            count=$((count + 1))
+            echo "$count" > "$BATS_TEST_TMPDIR/pr_create_count"
+            if [ "$count" -eq 1 ]; then
+                echo "GraphQL: API rate limit already exceeded" >&2
+                return 1
+            fi
+            echo "https://github.com/user/repo/pull/123"
+            return 0
+        fi
+        return 1
+    }
+    export -f gh
+
+    function wait_for_pr_checks() { return 0; }
+    function merge_pr_and_cleanup() { return 0; }
+    function sleep() { return 0; }
+    export -f wait_for_pr_checks merge_pr_and_cleanup sleep
+
+    run continuous_claude_commit "(1/1)" "test-branch" "main"
+
+    assert_success
+    assert_output --partial "Retrying (1/1) create PR in 1s"
+    assert_equal "$(cat "$BATS_TEST_TMPDIR/pr_create_count")" "2"
+}
+
 @test "merge_pr_and_cleanup surfaces GitHub plan restriction errors" {
     source "$SCRIPT_PATH"
 
@@ -2229,7 +2369,8 @@ require_pwsh() {
     # - has_changes will detect untracked files in parent repo
     # - After claude commits, verification will pass (ignoring dirty submodule)
     # - ls-files initially returns untracked files, then returns empty after commit
-    local commit_called=false
+    local commit_state="$BATS_TEST_TMPDIR/continuous_commit_called"
+    echo "false" > "$commit_state"
     function git() {
         case "$1 $2 $3 $4 $5" in
             "rev-parse --git-dir"*)
@@ -2246,7 +2387,7 @@ require_pwsh() {
                 ;;
             "ls-files --others"*)
                 # Return untracked files before commit, empty after
-                if [ "$commit_called" = "false" ]; then
+                if [ "$(cat "$commit_state")" = "false" ]; then
                     echo "newfile.txt"  # Simulates untracked file in parent repo
                 else
                     echo ""  # No untracked files after commit
@@ -2265,16 +2406,14 @@ require_pwsh() {
         return 0
     }
     export -f git
-    
-    commit_called=false
-    
+
     # Mock claude to succeed and mark that commit was called
     function claude() {
-        commit_called=true
+        echo "true" > "$commit_state"
         return 0
     }
     export -f claude
-    export commit_called
+    export commit_state
     
     # Run the function - it may fail on PR creation but commit verification should pass
     run continuous_claude_commit "(1/1)" "test-branch" "main"
@@ -2292,7 +2431,8 @@ require_pwsh() {
     DRY_RUN="false"
     
     # Mock git to simulate a repository with changes in parent repo AND a dirty submodule
-    local commit_called=false
+    local commit_state="$BATS_TEST_TMPDIR/current_branch_commit_called"
+    echo "false" > "$commit_state"
     function git() {
         case "$1 $2 $3 $4 $5" in
             "rev-parse --git-dir"*)
@@ -2306,7 +2446,7 @@ require_pwsh() {
                 ;;
             "ls-files --others"*)
                 # Return untracked files before commit, empty after
-                if [ "$commit_called" = "false" ]; then
+                if [ "$(cat "$commit_state")" = "false" ]; then
                     echo "newfile.txt"  # Simulates untracked file in parent repo
                 else
                     echo ""  # No untracked files after commit
@@ -2319,16 +2459,14 @@ require_pwsh() {
         return 0
     }
     export -f git
-    
-    commit_called=false
-    
+
     # Mock claude to succeed and mark that commit was called
     function claude() {
-        commit_called=true
+        echo "true" > "$commit_state"
         return 0
     }
     export -f claude
-    export commit_called
+    export commit_state
     
     # Run the function
     run commit_on_current_branch "(1/1)"
@@ -2336,6 +2474,68 @@ require_pwsh() {
     # Should succeed because --ignore-submodules=dirty allows dirty submodules
     assert_success
     assert_output --partial "Committed: Test commit"
+}
+
+@test "commit_on_current_branch retries transient commit failures" {
+    source "$SCRIPT_PATH"
+
+    DRY_RUN="false"
+    COMMAND_RETRY_MAX_ATTEMPTS=2
+    COMMAND_RETRY_BASE_DELAY=1
+
+    local commit_state="$BATS_TEST_TMPDIR/current_branch_retry_committed"
+    local commit_count="$BATS_TEST_TMPDIR/current_branch_retry_count"
+    echo "false" > "$commit_state"
+    echo "0" > "$commit_count"
+
+    function git() {
+        case "$1 $2 $3 $4 $5" in
+            "rev-parse --git-dir"*)
+                return 0
+                ;;
+            "diff --quiet"*)
+                if [ "$(cat "$commit_state")" = "true" ]; then
+                    return 0
+                fi
+                return 1
+                ;;
+            "diff --cached --quiet"*)
+                return 0
+                ;;
+            "ls-files --others"*)
+                echo ""
+                ;;
+            "log -1 --format=%s"*)
+                echo "Retry commit"
+                ;;
+        esac
+        return 0
+    }
+    export -f git
+
+    function claude() {
+        local count
+        count=$(cat "$commit_count")
+        count=$((count + 1))
+        echo "$count" > "$commit_count"
+        if [ "$count" -eq 1 ]; then
+            echo "temporary commit failure" >&2
+            return 1
+        fi
+
+        echo "true" > "$commit_state"
+        return 0
+    }
+    function sleep() { return 0; }
+    export -f claude sleep
+    export commit_state commit_count
+
+    run commit_on_current_branch "(1/1)"
+
+    assert_success
+    assert_output --partial "Retrying (1/1) commit command in 1s"
+    assert_output --partial "Committed: Retry commit"
+    assert_equal "$(cat "$commit_count")" "2"
 }
 
 @test "commit_on_current_branch uses Codex provider when selected" {
@@ -2734,6 +2934,8 @@ require_pwsh() {
     run show_help
     assert_output --partial "--disable-comment-review"
     assert_output --partial "--comment-review-max"
+    assert_output --partial "--command-retry-max"
+    assert_output --partial "--command-retry-base-delay"
     assert_output --partial "--review-prompt [text]"
     assert_output --partial "Uses a comprehensive default review prompt"
 }


### PR DESCRIPTION
## Summary
- add exponential retry handling for commit commands, branch pushes, and PR creation
- expose retry attempt and base-delay flags in the CLI and README
- cover command retry, PR creation retry, and current-branch commit retry behavior in tests

Closes #31

## Tests
- tests/libs/bats/bin/bats tests/test_continuous_claude.bats
- bash -n continuous_claude.sh install.sh
- shellcheck continuous_claude.sh install.sh
- git diff --check
- sha256sum -c continuous_claude.sh.sha256