### PR TITLE
Add health-based stall stopping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,7 +301,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Stage and commit changes
-          git add continuous_claude.sh continuous_claude.sh.sha256 CHANGELOG.md
+          git add continuous_claude.sh continuous_claude.sh.sha256 continuous_claude.ps1 continuous_claude.ps1.sha256 CHANGELOG.md
           git commit -m ":bookmark: Release version $NEW_VERSION"
 
           # Push to main

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ continuous-claude --prompt "add unit tests until all code is covered" --max-dura
 - `--dry-run`: Simulate execution without making changes
 - `--completion-signal <phrase>`: Phrase that agents output when entire project is complete (default: `CONTINUOUS_CLAUDE_PROJECT_COMPLETE`)
 - `--completion-threshold <num>`: Number of consecutive completion signals required to stop early (default: `3`)
+- `--stall-threshold <number>`: Pause after this many consecutive failures and append diagnostics to the notes file for human intervention
 - `-r, --review-prompt [text]`: Run a reviewer pass after each iteration to validate changes. If you omit the text, Continuous Claude uses a comprehensive default review prompt that reviews the diff, runs available checks, simplifies changed code, and verifies the app where relevant.
 - `--command-retry-max <number>`: Maximum attempts for transient commit/push/PR-create commands before starting a new iteration (default: `3`)
 - `--command-retry-base-delay <seconds>`: Initial retry delay in seconds for transient commands, doubled after each failed attempt (default: `5`)
@@ -265,6 +266,9 @@ continuous-claude -p "add unit tests to all files" -m 50 --completion-threshold 
 
 # Use custom completion signal
 continuous-claude -p "fix all bugs" -m 20 --completion-signal "ALL_BUGS_FIXED" --completion-threshold 2
+
+# Pause and write diagnostics to SHARED_TASK_NOTES.md after repeated failures
+continuous-claude -p "stabilize CI" -m 20 --stall-threshold 3
 
 # Use a reviewer to validate and fix changes after each iteration
 continuous-claude -p "add new feature" -m 5 -r "Run npm test and npm run lint, fix any failures"

--- a/continuous_claude.ps1
+++ b/continuous_claude.ps1
@@ -3,7 +3,7 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-$script:Version = "v0.24.0"
+$script:Version = "v0.24.3"
 $script:ClaudeFlags = @("--dangerously-skip-permissions", "--output-format", "stream-json", "--verbose")
 $script:CodexFlags = @("--json", "--dangerously-bypass-approvals-and-sandbox", "--skip-git-repo-check")
 
@@ -107,6 +107,7 @@ OPTIONAL FLAGS:
     --dry-run                       Simulate execution without making changes
     --completion-signal <phrase>    Phrase agents output when project is complete
     --completion-threshold <num>    Consecutive signals required to stop early (default: 3)
+    --stall-threshold <number>      Bash-runner only; pause after repeated failures and write diagnostics
     -r, --review-prompt [text]      Run a reviewer pass after each iteration; uses a default prompt when text is omitted
     --codex-input-cost-per-million <dollars>
                                     Input token rate for Codex --max-cost estimates
@@ -279,6 +280,9 @@ function Parse-Arguments {
                 $script:CompletionThreshold = [int](Need-Value $Items $i $arg)
                 $i += 2
                 continue
+            }
+            "^--stall-threshold$" {
+                Exit-UnsupportedFlag $arg
             }
             "^--review-prompt=.*$" {
                 $script:ReviewPrompt = $arg.Substring("--review-prompt=".Length)

--- a/continuous_claude.ps1.sha256
+++ b/continuous_claude.ps1.sha256
@@ -1,1 +1,1 @@
-bcebff300e66b7a48bd863b57702a6a78a7e705056715973cca091f2a56ca44d  continuous_claude.ps1
+d6d2fc103998db98d8845b5dc06fae514d97153a0e32be2beb02d19dbeb4ebb8  continuous_claude.ps1

--- a/continuous_claude.sh
+++ b/continuous_claude.sh
@@ -110,6 +110,7 @@ LIST_WORKTREES=false
 DRY_RUN=false
 COMPLETION_SIGNAL="CONTINUOUS_CLAUDE_PROJECT_COMPLETE"
 COMPLETION_THRESHOLD=3
+STALL_THRESHOLD=""
 ERROR_LOG=""
 error_count=0
 extra_iterations=0
@@ -240,6 +241,7 @@ OPTIONAL FLAGS:
     --dry-run                     Simulate execution without making changes
     --completion-signal <phrase>  Phrase that agents output when project is complete (default: "CONTINUOUS_CLAUDE_PROJECT_COMPLETE")
     --completion-threshold <num>  Number of consecutive signals to stop early (default: 3)
+    --stall-threshold <number>    Pause after N consecutive failures and write diagnostics to the notes file
     -r, --review-prompt [text]    Run a reviewer pass after each iteration to validate changes
                                   Uses a comprehensive default review prompt when text is omitted
                                   (e.g., run build/lint/tests and fix any issues)
@@ -941,6 +943,10 @@ parse_arguments() {
                 COMPLETION_THRESHOLD="$2"
                 shift 2
                 ;;
+            --stall-threshold)
+                STALL_THRESHOLD="$2"
+                shift 2
+                ;;
             --review-prompt=*)
                 REVIEW_PROMPT="${1#*=}"
                 if [ -z "$REVIEW_PROMPT" ]; then
@@ -1090,6 +1096,13 @@ validate_arguments() {
     if [ -n "$COMPLETION_THRESHOLD" ]; then
         if ! [[ "$COMPLETION_THRESHOLD" =~ ^[0-9]+$ ]] || [ "$COMPLETION_THRESHOLD" -lt 1 ]; then
             echo "❌ Error: --completion-threshold must be a positive integer" >&2
+            exit 1
+        fi
+    fi
+
+    if [ -n "$STALL_THRESHOLD" ]; then
+        if ! [[ "$STALL_THRESHOLD" =~ ^[0-9]+$ ]] || [ "$STALL_THRESHOLD" -lt 1 ]; then
+            echo "❌ Error: --stall-threshold must be a positive integer" >&2
             exit 1
         fi
     fi
@@ -2672,6 +2685,106 @@ extract_agent_usage_summary() {
     '
 }
 
+repo_has_pending_changes() {
+    if ! git rev-parse --git-dir > /dev/null 2>&1; then
+        return 1
+    fi
+
+    if ! git diff --quiet --ignore-submodules=dirty || ! git diff --cached --quiet --ignore-submodules=dirty; then
+        return 0
+    fi
+
+    if [ -n "$(git ls-files --others --exclude-standard)" ]; then
+        return 0
+    fi
+
+    return 1
+}
+
+detect_positive_completion_heuristic() {
+    local result_text="$1"
+
+    if [ -z "$result_text" ]; then
+        return 1
+    fi
+
+    local normalized
+    normalized=$(printf "%s" "$result_text" | tr '[:upper:]' '[:lower:]')
+
+    case "$normalized" in
+        *"all scoped tasks complete"*|*"all requested tasks complete"*|*"all tasks complete"*|*"nothing left to do"*|*"no remaining work"*)
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
+get_recent_failure_details() {
+    local fallback="${1:-}"
+
+    if [ -n "$ERROR_LOG" ] && [ -f "$ERROR_LOG" ] && [ -s "$ERROR_LOG" ]; then
+        tail -n 80 "$ERROR_LOG"
+    elif [ -n "$fallback" ]; then
+        printf "%s\n" "$fallback" | tail -n 80
+    else
+        echo "No diagnostics captured."
+    fi
+}
+
+append_stall_summary() {
+    local iteration_display="$1"
+    local reason="$2"
+    local details="${3:-}"
+
+    local notes_dir
+    notes_dir=$(dirname "$NOTES_FILE")
+    if [ "$notes_dir" != "." ]; then
+        mkdir -p "$notes_dir"
+    fi
+
+    {
+        echo ""
+        echo "## Health pause - $(date '+%Y-%m-%d %H:%M:%S %Z')"
+        echo ""
+        echo "- Iteration: $iteration_display"
+        echo "- Consecutive failures: $error_count"
+        echo "- Reason: $reason"
+        echo ""
+        echo "Recent diagnostics:"
+        get_recent_failure_details "$details" | sed 's/^/    /'
+        echo ""
+        echo "Next step: Inspect the failure, fix the project or adjust the prompt, then rerun Continuous Claude."
+    } >> "$NOTES_FILE"
+}
+
+maybe_handle_stall_threshold() {
+    local iteration_display="$1"
+    local reason="$2"
+    local details="${3:-}"
+
+    if [ -n "$STALL_THRESHOLD" ] && [ "$error_count" -ge "$STALL_THRESHOLD" ]; then
+        append_stall_summary "$iteration_display" "$reason" "$details"
+        echo "⏸️  $iteration_display Health stall threshold reached ($error_count/$STALL_THRESHOLD consecutive failures)" >&2
+        echo "📝 $iteration_display Wrote stall diagnostics to $NOTES_FILE" >&2
+
+        if [ -t 0 ]; then
+            echo "Press Enter after human intervention to continue, or Ctrl+C to exit." >&2
+            read -r _
+            error_count=0
+            return 0
+        fi
+
+        echo "❌ $iteration_display Non-interactive shell detected; exiting so a human can intervene." >&2
+        exit 1
+    fi
+
+    if [ -z "$STALL_THRESHOLD" ] && [ "$error_count" -ge 3 ]; then
+        echo "❌ Fatal: 3 consecutive errors occurred. Exiting." >&2
+        exit 1
+    fi
+}
+
 handle_iteration_error() {
     local iteration_display="$1"
     local error_type="$2"
@@ -2724,10 +2837,7 @@ handle_iteration_error() {
             ;;
     esac
     
-    if [ "$error_count" -ge 3 ]; then
-        echo "❌ Fatal: 3 consecutive errors occurred. Exiting." >&2
-        exit 1
-    fi
+    maybe_handle_stall_threshold "$iteration_display" "$error_type" "$error_output"
     
     return 1
 }
@@ -2740,18 +2850,9 @@ handle_iteration_success() {
     
     local result_text
     result_text=$(extract_agent_result_text "$result")
-
-    # Check for completion signal in the output
+    local explicit_completion_detected=false
     if [ -n "$result_text" ] && [[ "$result_text" == *"$COMPLETION_SIGNAL"* ]]; then
-        completion_signal_count=$((completion_signal_count + 1))
-        echo "" >&2
-        echo "🎯 $iteration_display Completion signal detected ($completion_signal_count/$COMPLETION_THRESHOLD)" >&2
-    else
-        if [ "$completion_signal_count" -gt 0 ]; then
-            echo "" >&2
-            echo "🔄 $iteration_display Completion signal not found, resetting counter" >&2
-        fi
-        completion_signal_count=0
+        explicit_completion_detected=true
     fi
 
     local cost
@@ -2777,10 +2878,7 @@ handle_iteration_success() {
                 error_count=$((error_count + 1))
                 extra_iterations=$((extra_iterations + 1))
                 echo "❌ $iteration_display Commit failed ($error_count consecutive errors)" >&2
-                if [ "$error_count" -ge 3 ]; then
-                    echo "❌ Fatal: 3 consecutive errors occurred. Exiting." >&2
-                    exit 1
-                fi
+                maybe_handle_stall_threshold "$iteration_display" "commit failed"
                 return 1
             fi
         else
@@ -2789,10 +2887,7 @@ handle_iteration_success() {
                 error_count=$((error_count + 1))
                 extra_iterations=$((extra_iterations + 1))
                 echo "❌ $iteration_display PR workflow failed ($error_count consecutive errors)" >&2
-                if [ "$error_count" -ge 3 ]; then
-                    echo "❌ Fatal: 3 consecutive errors occurred. Exiting." >&2
-                    exit 1
-                fi
+                maybe_handle_stall_threshold "$iteration_display" "PR workflow failed"
                 return 1
             fi
         fi
@@ -2803,6 +2898,22 @@ handle_iteration_success() {
             git checkout "$main_branch" >/dev/null 2>&1
             git branch -D "$branch_name" >/dev/null 2>&1 || true
         fi
+    fi
+
+    if [ "$explicit_completion_detected" = "true" ]; then
+        completion_signal_count=$((completion_signal_count + 1))
+        echo "" >&2
+        echo "🎯 $iteration_display Completion signal detected ($completion_signal_count/$COMPLETION_THRESHOLD)" >&2
+    elif detect_positive_completion_heuristic "$result_text" && ! repo_has_pending_changes; then
+        completion_signal_count=$((completion_signal_count + 1))
+        echo "" >&2
+        echo "🩺 $iteration_display Positive completion heuristic detected ($completion_signal_count/$COMPLETION_THRESHOLD)" >&2
+    else
+        if [ "$completion_signal_count" -gt 0 ]; then
+            echo "" >&2
+            echo "🔄 $iteration_display Completion signal not found, resetting counter" >&2
+        fi
+        completion_signal_count=0
     fi
     
     error_count=0
@@ -2910,10 +3021,7 @@ $notes_content
             # Count as an error for consecutive error tracking
             error_count=$((error_count + 1))
             extra_iterations=$((extra_iterations + 1))
-            if [ "$error_count" -ge 3 ]; then
-                echo "❌ Fatal: 3 consecutive errors occurred. Exiting." >&2
-                exit 1
-            fi
+            maybe_handle_stall_threshold "$iteration_display" "reviewer failed"
             return 1
         fi
     fi

--- a/continuous_claude.sh.sha256
+++ b/continuous_claude.sh.sha256
@@ -1,1 +1,1 @@
-d7836efc0ed0a1f294b4afe13835b2d16f3beb24e1e2023765a30f05958f3b31  continuous_claude.sh
+09b44b5745b9a7b5a65097efa1e569306344a1ef07917fd714b167da1dc0eb9e  continuous_claude.sh

--- a/tests/test_continuous_claude.bats
+++ b/tests/test_continuous_claude.bats
@@ -57,6 +57,7 @@ require_pwsh() {
     assert_success
     assert_output --partial "Continuous Claude PowerShell"
     assert_output --partial "--review-prompt [text]"
+    assert_output --partial "--stall-threshold <number>"
 }
 
 @test "powershell dry run supports empty reviewer prompt" {
@@ -111,6 +112,12 @@ require_pwsh() {
 
     assert_failure
     assert_output --partial "--worktree is not supported by the native PowerShell runner yet"
+
+    run pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File "$PS_SCRIPT_PATH" \
+        -p "test" -m 1 --stall-threshold 2
+
+    assert_failure
+    assert_output --partial "--stall-threshold is not supported by the native PowerShell runner yet"
 }
 
 @test "parse_arguments handles required flags" {
@@ -577,11 +584,19 @@ require_pwsh() {
     assert_equal "$COMPLETION_THRESHOLD" "5"
 }
 
+@test "parse_arguments handles stall-threshold flag" {
+    source "$SCRIPT_PATH"
+    parse_arguments --stall-threshold 4
+
+    assert_equal "$STALL_THRESHOLD" "4"
+}
+
 @test "parse_arguments sets default completion values" {
     source "$SCRIPT_PATH"
     
     assert_equal "$COMPLETION_SIGNAL" "CONTINUOUS_CLAUDE_PROJECT_COMPLETE"
     assert_equal "$COMPLETION_THRESHOLD" "3"
+    assert_equal "$STALL_THRESHOLD" ""
 }
 
 @test "validate_arguments fails with invalid completion-threshold" {
@@ -608,6 +623,32 @@ require_pwsh() {
     run validate_arguments
     assert_failure
     assert_output --partial "Error: --completion-threshold must be a positive integer"
+}
+
+@test "validate_arguments fails with invalid stall-threshold" {
+    source "$SCRIPT_PATH"
+    PROMPT="test"
+    MAX_RUNS="5"
+    GITHUB_OWNER="user"
+    GITHUB_REPO="repo"
+    STALL_THRESHOLD="invalid"
+
+    run validate_arguments
+    assert_failure
+    assert_output --partial "Error: --stall-threshold must be a positive integer"
+}
+
+@test "validate_arguments fails with zero stall-threshold" {
+    source "$SCRIPT_PATH"
+    PROMPT="test"
+    MAX_RUNS="5"
+    GITHUB_OWNER="user"
+    GITHUB_REPO="repo"
+    STALL_THRESHOLD="0"
+
+    run validate_arguments
+    assert_failure
+    assert_output --partial "Error: --stall-threshold must be a positive integer"
 }
 
 @test "validate_arguments passes with valid completion-threshold" {
@@ -733,6 +774,77 @@ require_pwsh() {
     assert_success
     assert_output --partial "Completion signal detected (1/2)"
     assert_output --partial "Tokens: input 100, cached input 0, output 20"
+}
+
+@test "positive completion heuristic increments counter when repo is clean" {
+    source "$SCRIPT_PATH"
+
+    completion_signal_count=0
+    total_cost=0
+    COMPLETION_THRESHOLD=3
+    ENABLE_COMMITS="false"
+
+    local result='{"result": "All scoped tasks complete.", "total_cost_usd": 0.1}'
+
+    function git() {
+        case "$1 $2 $3" in
+            "rev-parse --git-dir")
+                return 0
+                ;;
+            "diff --quiet --ignore-submodules=dirty")
+                return 0
+                ;;
+            "diff --cached --quiet")
+                return 0
+                ;;
+            "ls-files --others --exclude-standard")
+                echo ""
+                ;;
+        esac
+        return 0
+    }
+    export -f git
+
+    run handle_iteration_success "(1/3)" "$result" "" "main"
+
+    assert_success
+    assert_output --partial "Positive completion heuristic detected (1/3)"
+}
+
+@test "positive completion heuristic waits when repo has pending changes" {
+    source "$SCRIPT_PATH"
+
+    completion_signal_count=1
+    total_cost=0
+    COMPLETION_THRESHOLD=3
+    ENABLE_COMMITS="false"
+
+    local result='{"result": "All scoped tasks complete.", "total_cost_usd": 0.1}'
+
+    function git() {
+        case "$1 $2 $3" in
+            "rev-parse --git-dir")
+                return 0
+                ;;
+            "diff --quiet --ignore-submodules=dirty")
+                return 1
+                ;;
+            "diff --cached --quiet")
+                return 0
+                ;;
+            "ls-files --others --exclude-standard")
+                echo ""
+                ;;
+        esac
+        return 0
+    }
+    export -f git
+
+    run handle_iteration_success "(1/3)" "$result" "" "main"
+
+    assert_success
+    assert_output --partial "Completion signal not found, resetting counter"
+    refute_output --partial "Positive completion heuristic detected"
 }
 
 @test "show_completion_summary shows signal message" {
@@ -991,6 +1103,28 @@ require_pwsh() {
     run grep -q "exec" "$args_file"
     assert_success
     run grep -q "commit please" "$args_file"
+    assert_success
+}
+
+@test "handle_iteration_error writes notes and exits at stall threshold" {
+    source "$SCRIPT_PATH"
+
+    STALL_THRESHOLD=2
+    error_count=1
+    extra_iterations=0
+    NOTES_FILE="$BATS_TEST_TMPDIR/health-notes.md"
+    ERROR_LOG="$BATS_TEST_TMPDIR/error.log"
+    echo "lint failed in src/app.js" > "$ERROR_LOG"
+
+    run handle_iteration_error "(2/5)" "exit_code" ""
+
+    assert_failure
+    assert_output --partial "Health stall threshold reached (2/2 consecutive failures)"
+    assert_output --partial "Wrote stall diagnostics to $NOTES_FILE"
+    assert [ -f "$NOTES_FILE" ]
+    run grep -q "Health pause" "$NOTES_FILE"
+    assert_success
+    run grep -q "lint failed in src/app.js" "$NOTES_FILE"
     assert_success
 }
 
@@ -2936,6 +3070,7 @@ require_pwsh() {
     assert_output --partial "--comment-review-max"
     assert_output --partial "--command-retry-max"
     assert_output --partial "--command-retry-base-delay"
+    assert_output --partial "--stall-threshold"
     assert_output --partial "--review-prompt [text]"
     assert_output --partial "Uses a comprehensive default review prompt"
 }


### PR DESCRIPTION
## Summary
- add an opt-in `--stall-threshold` that records repeated failure diagnostics in the notes file and pauses for human intervention
- add a conservative positive completion heuristic for clean repos when the agent says all scoped work is complete
- document the new flag and add Bats coverage for parsing, validation, stall notes, and heuristic stopping
- fix release automation so PowerShell script/version checksum changes are staged, and align the PowerShell runner version with the current release

Closes #29

## Tests
- tests/libs/bats/bin/bats tests/test_continuous_claude.bats
- bash -n continuous_claude.sh install.sh
- shellcheck continuous_claude.sh install.sh
- pwsh parser check for continuous_claude.ps1
- git diff --check
- sha256sum -c continuous_claude.sh.sha256 && sha256sum -c continuous_claude.ps1.sha256