### PR TITLE
:pencil: Document GitHub platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ Before using `continuous-claude`, you need:
 2. **[GitHub CLI](https://cli.github.com)** - Authenticate with `gh auth login`
 3. **jq** - Install with `brew install jq` (macOS) or `apt-get install jq` (Linux). The PowerShell runner uses native JSON parsing and does not require `jq`.
 
+### Platform support
+
+Continuous Claude currently automates the GitHub pull request workflow. It detects GitHub remotes, creates PRs with `gh pr create`, waits for GitHub checks and reviews, and merges through GitHub's API.
+
+Self-hosted Git forges such as Gitea are not supported yet because they use different pull request, check, and review APIs. You can still run Continuous Claude in a local-only mode with `--disable-commits` or on the current branch with `--disable-branches`, but full PR automation requires a GitHub repository today.
+
 ### Usage
 
 ```bash


### PR DESCRIPTION
## Summary
- Documents that Continuous Claude currently supports GitHub PR automation only
- Explains why Gitea/self-hosted Git forge support needs separate PR/check/review API work
- Points users to local-only/current-branch modes when full PR automation is not needed

## Test plan
- `./tests/setup.sh`
- `./tests/libs/bats/bin/bats tests/test_continuous_claude.bats`

Refs #44
