### PR TITLE
:construction_worker: Update checkout action to v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
 
       - name: Install dependencies
         run: |
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0 # Fetch all history for all tags and branches
           fetch-tags: true # Explicitly fetch all tags

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- updates all `actions/checkout` uses from v4 to v7.0.0
- moves workflow checkout steps to the current Node 24 action runtime
- keeps the change workflow-only, so the release workflow should skip publishing

## Test plan
- [x] 183 Bats tests pass (11 PowerShell-only tests skipped because `pwsh` is unavailable)
- [x] both workflows parse as YAML
- [x] actionlint structural validation passes
- [x] `bash -n` passes for Bash scripts
- [x] tracked script checksums verify
- [x] GitHub API confirms `actions/checkout@v7.0.0` exists and uses `node24`
