### PR TITLE
:bug: Synchronize provider stderr capture

### DIFF
--- a/continuous_claude.sh
+++ b/continuous_claude.sh
@@ -2086,13 +2086,18 @@ run_claude_provider_iteration() {
     # Use temporary files for both to ensure synchronous capture
     local temp_stdout=$(mktemp)
     local temp_stderr=$(mktemp)
+    local temp_stderr_fifo="${temp_stderr}.fifo"
     local exit_code=0
+
+    mkfifo "$temp_stderr_fifo"
+    tee "$temp_stderr" < "$temp_stderr_fifo" >&2 &
+    local stderr_tee_pid=$!
 
     # Stream stdout (stream-json) to terminal in human-readable format while capturing raw JSON
     # Filter extracts text from assistant messages for display
     set -o pipefail
     # shellcheck disable=SC2086
-    claude -p "$prompt" $flags "${EXTRA_AGENT_FLAGS[@]}" 2> >(tee "$temp_stderr" >&2) | \
+    claude -p "$prompt" $flags "${EXTRA_AGENT_FLAGS[@]}" 2>"$temp_stderr_fifo" | \
         tee "$temp_stdout" | \
         while IFS= read -r line; do
             # Extract text from assistant messages for human-readable display
@@ -2213,8 +2218,9 @@ run_claude_provider_iteration() {
     exit_code=${PIPESTATUS[0]}
     set +o pipefail
 
-    # Wait for background processes to complete
-    wait
+    # Wait for stderr to be fully captured before inspecting the error log.
+    wait "$stderr_tee_pid"
+    rm -f "$temp_stderr_fifo"
 
     # Output captured stdout (JSON result) so caller can capture it
     if [ -f "$temp_stdout" ] && [ -s "$temp_stdout" ]; then
@@ -2280,11 +2286,16 @@ run_codex_provider_iteration() {
 
     local temp_stdout=$(mktemp)
     local temp_stderr=$(mktemp)
+    local temp_stderr_fifo="${temp_stderr}.fifo"
     local exit_code=0
+
+    mkfifo "$temp_stderr_fifo"
+    tee "$temp_stderr" < "$temp_stderr_fifo" >&2 &
+    local stderr_tee_pid=$!
 
     set -o pipefail
     # shellcheck disable=SC2086
-    codex exec $flags -C "$PWD" "${EXTRA_AGENT_FLAGS[@]}" "$prompt" 2> >(tee "$temp_stderr" >&2) | \
+    codex exec $flags -C "$PWD" "${EXTRA_AGENT_FLAGS[@]}" "$prompt" 2>"$temp_stderr_fifo" | \
         tee "$temp_stdout" | \
         while IFS= read -r line; do
             text=$(echo "$line" | jq -r '
@@ -2323,7 +2334,8 @@ run_codex_provider_iteration() {
     exit_code=${PIPESTATUS[0]}
     set +o pipefail
 
-    wait
+    wait "$stderr_tee_pid"
+    rm -f "$temp_stderr_fifo"
 
     if [ -f "$temp_stdout" ] && [ -s "$temp_stdout" ]; then
         cat "$temp_stdout"

--- a/continuous_claude.sh.sha256
+++ b/continuous_claude.sh.sha256
@@ -1,1 +1,1 @@
-5e8288dd13dd447db315a0a072cac61e74ff05e64935dd08039c1ff333884bf8  continuous_claude.sh
+39f9762971e23d2fe8fa4c7c5acb4b6760530502d13e63055aed9cf92c4e918f  continuous_claude.sh


### PR DESCRIPTION
## Summary
- fixes a race where provider stderr could be inspected before the asynchronous `tee` process had written it
- uses a FIFO plus an explicitly awaited `tee` process for both Claude and Codex providers
- keeps stderr streaming live while guaranteeing complete error-log capture
- refreshes the tracked Bash script checksum

## Root cause
Post-merge Create Release CI for #65 failed twice in the existing `run_agent_iteration captures Codex stderr to error log` regression. The mocked Codex process wrote `Codex auth failed`, but the generic `wait` did not reliably wait for the pipeline's process substitution, so the code saw an empty stderr file and generated its fallback message instead.

## Test plan
- [x] reproduced the flaky failure locally before the fix and in Create Release CI attempts 1 and 2
- [x] FIFO synchronization micro-reproduction passed 100/100 iterations
- [x] Claude/Codex stderr-capture regressions passed 20 consecutive runs
- [x] full 183-test Bats suite passed three consecutive runs
- [x] `bash -n` passes
- [x] tracked SHA-256 checksum verifies
- [x] `git diff --check` and added-line security scan pass

Follow-up to #65.
